### PR TITLE
Restore `Missing._Missing` module.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 4.1 (unreleased)
 ----------------
 
+- Restore `Missing._Missing` module for pickle compatibility with the old
+  C extension version.
 
 4.0 (2017-05-16)
 ----------------

--- a/src/Missing/_Missing.py
+++ b/src/Missing/_Missing.py
@@ -1,0 +1,2 @@
+# BBB
+from . import Missing, V, MV, Value, notMissing  # noqa


### PR DESCRIPTION
This is needed for pickle compatibility with the old C extension version.

Fixes #3 