### PR TITLE
Switch to trusted publishing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
         && matrix.config[1] == 'py314'
       run: |
         rm -f dist/*
-        pip install -U "setuptools >= 78.1.1,< 82" wheel twine
+        pip install -U packaging "setuptools >= 78.1.1,< 82" wheel twine
         python setup.py sdist
         python setup.py bdist_wheel
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,8 @@ jobs:
       with:
         persist-credentials: false
     - name: Install uv + caching
-      # astral/setup-uv@7.5.0
-      uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82
+      # astral/setup-uv@8.1.0
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
       with:
         enable-cache: true
         cache-dependency-glob: |
@@ -57,3 +57,26 @@ jobs:
         uvx coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build release packages
+      if: >
+        github.event_name == 'push'
+        && startsWith(github.ref, 'refs/tags')
+        && matrix.os[0] == 'ubuntu'
+        && matrix.config[1] == 'py314'
+      run: |
+        rm -f dist/*
+        python setup.py sdist
+        python setup.py bdist_wheel
+
+    - name: Publish release to PyPI
+      if: >
+        github.event_name == 'push'
+        && startsWith(github.ref, 'refs/tags')
+        && matrix.os[0] == 'ubuntu'
+        && matrix.config[1] == 'py314'
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        skip-existing: true
+        packages-dir: dist/
+        verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,8 @@ jobs:
         matrix.os[0] == 'ubuntu'
         && matrix.config[1] == 'py314'
       uses: actions/upload-artifact@v7
-      path: dist/*
+      with:
+        path: dist/*
 
   publish:
     name: Publish to PyPI

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,13 +68,23 @@ jobs:
         python setup.py sdist
         python setup.py bdist_wheel
 
-    - name: Upload package artifacts
+    - name: Upload package wheel
       if: >
         matrix.os[0] == 'ubuntu'
         && matrix.config[1] == 'py314'
       uses: actions/upload-artifact@v7
       with:
-        path: dist/*
+        name: Missing.whl
+        path: dist/*whl
+
+    - name: Upload package source distribution
+      if: >
+        matrix.os[0] == 'ubuntu'
+        && matrix.config[1] == 'py314'
+      uses: actions/upload-artifact@v7
+      with:
+        name: Missing.tar.gz
+        path: dist/*gz
 
   publish:
     name: Publish to PyPI

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      id-token: write  # Mandatory for trusted publishing
-    environment:
-      name: pypi
-      url: https://pypi.org/p/Missing
     strategy:
       # We want to see all failures:
       fail-fast: false
@@ -62,25 +58,51 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build release packages
+    - name: Build package artifacts
       if: >
-        github.event_name == 'push'
-        && startsWith(github.ref, 'refs/tags')
-        && matrix.os[0] == 'ubuntu'
+        matrix.os[0] == 'ubuntu'
         && matrix.config[1] == 'py314'
       run: |
         rm -f dist/*
         python setup.py sdist
         python setup.py bdist_wheel
 
-    - name: Publish release to PyPI
+    - name: Upload package artifacts
       if: >
-        github.event_name == 'push'
-        && startsWith(github.ref, 'refs/tags')
-        && matrix.os[0] == 'ubuntu'
+        matrix.os[0] == 'ubuntu'
         && matrix.config[1] == 'py314'
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        skip-existing: true
-        packages-dir: dist/
-        verbose: true
+      uses: actions/upload-artifact@v7
+      path: dist/*
+
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    # Only publish on tag pushes
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    # Wait for build jobs to complete
+    needs: [build]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/Missing
+    permissions:
+      contents: read
+      id-token: write  # Mandatory for trusted publishing
+
+    steps:
+      - name: Download package artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: dist/
+          pattern: '*'
+          merge-multiple: true
+
+      - name: Display structure of downloaded files
+        run: |
+          ls -lR dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+          packages-dir: dist/
+          verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,10 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write  # Mandatory for trusted publishing
+    environment:
+      name: pypi
+      url: https://pypi.org/p/Missing
     strategy:
       # We want to see all failures:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,6 +64,7 @@ jobs:
         && matrix.config[1] == 'py314'
       run: |
         rm -f dist/*
+        pip install -U "setuptools >= 78.1.1,< 82" wheel twine
         python setup.py sdist
         python setup.py bdist_wheel
 

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 [meta]
 template = "pure-python"
-commit-id = "9832deed"
+commit-id = "4a3c19b7"
 
 [python]
 with-future-python = false
@@ -28,3 +28,6 @@ testenv-skip-test-extra = true
 testenv-deps = [
     "zope.testrunner",
     ]
+
+[pypi]
+trusted-publishing = true

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 [meta]
 template = "pure-python"
-commit-id = "4a3c19b7"
+commit-id = "5d13ebe9"
 
 [python]
 with-future-python = false

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 [meta]
 template = "pure-python"
-commit-id = "5d13ebe9"
+commit-id = "06024ba5"
 
 [python]
 with-future-python = false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 minimum_pre_commit_version: '3.6'
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: "7.0.0"
+    rev: "8.0.1"
     hooks:
     - id: isort
   - repo: https://github.com/hhatto/autopep8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 5.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Switch to Trusted Publishing for the tag and release process.
+  When a tag is pushed to GitHub, the ``tests`` action will automatically
+  build a source distribution and a wheel and publish them to PyPI.
 
 
 5.1 (2026-03-18)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,7 @@ directory = "parts/htmlcov"
 
 [tool.setuptools.dynamic]
 readme = {file = ["README.rst", "CHANGES.rst"]}
+
+[tool.zest-releaser]
+create-wheel = false
+upload-pypi = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Missing"
-version = "5.2.dev0"
+version = "5.2a1"
 description = "Special Missing objects used in Zope."
 license = "ZPL-2.1"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "Missing"
 version = "5.2a1"
 description = "Special Missing objects used in Zope."
-license-expression = "ZPL-2.1"
+license = "ZPL-2.1"
 classifiers = [
     "Development Status :: 6 - Mature",
     "Environment :: Web Environment",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 name = "Missing"
 version = "5.2a1"
 description = "Special Missing objects used in Zope."
-license = "ZPL-2.1"
+license-expression = "ZPL-2.1"
 classifiers = [
     "Development Status :: 6 - Mature",
     "Environment :: Web Environment",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,10 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 [build-system]
 requires = [
-    "setuptools >= 78.1.1,< 81",
+    "setuptools >= 78.1.1,< 82",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"
-
 
 [project]
 name = "Missing"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 # Generated with zope.meta (https://zopemeta.readthedocs.io/) from:
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
-
 [flake8]
 doctests = 1
 # F401 Module imported but unused

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ usedevelop = true
 package = wheel
 wheel_build_env = .pkg
 deps =
-    setuptools >= 78.1.1,< 81
+    setuptools >= 78.1.1,< 82
     zope.testrunner
 commands =
     zope-testrunner --test-path=src {posargs:-vc}
@@ -35,12 +35,12 @@ description = ensure that the distribution is ready to release
 basepython = python3
 skip_install = true
 deps =
-    setuptools >= 78.1.1,< 81
+    setuptools >= 78.1.1,< 82
     wheel
     twine
     build
     check-manifest
-    check-python-versions >= 0.20.0
+    check-python-versions >= 0.24.2
     wheel
 commands_pre =
 commands =


### PR DESCRIPTION
This PR is the result of applying the new test template that includes publishing the wheel/sdist to PyPI.

zope.meta changes: https://github.com/zopefoundation/meta/pull/418

Successful test run with publishing output see https://github.com/zopefoundation/Missing/actions/runs/25437190282/job/74618232499

The test release 5.2a1 on PyPI at https://pypi.org/project/Missing/5.2a1/
